### PR TITLE
Tetris: Faster falling and new scoring

### DIFF
--- a/Scenes/Tetris/scripts/game.gd
+++ b/Scenes/Tetris/scripts/game.gd
@@ -46,12 +46,16 @@ func start_game() -> void:
 	game_state.game_over.connect(on_game_over)
 	game_state.preview_figure.connect(on_draw_next_piece)
 	game_state.line_broken.connect(on_line_broken)
+	game_state.level_change.connect(on_level_change)
 	
 	game_state.new_figure()
 	game_state.pieces_placed = 0
 	draw_everything()
 	_timer.start()
 	_ms_started = Time.get_ticks_msec()
+
+func on_level_change(level: int) -> void:
+	_timer.wait_time = (0.8-(level*0.007))**(level)
 
 func draw_everything() -> void:
 	draw_board()
@@ -90,7 +94,9 @@ func pause_game(paused: bool) -> void:
 ## Moves the active tetramino down and draws the board
 func go_down() -> void:
 	game_state.go_down()
+	game_state.score += 1
 	draw_board()
+	draw_score()
 
 ## On line broken callback - dreaws the score and lines broken
 func on_line_broken() -> void:

--- a/Scenes/Tetris/scripts/tetris.gd
+++ b/Scenes/Tetris/scripts/tetris.gd
@@ -12,11 +12,12 @@ var pieces_placed := 0
 signal game_over
 signal preview_figure
 signal line_broken
+signal level_change(level: int)
 
 func _init(new_height: int, new_width: int) -> void:
+	score = 0
 	lines_broken = 0
 	pieces_placed = 0
-	score = 0
 	height = new_height
 	width = new_width
 	next_figure = Figure.new(int(float(width) / 2) - 1, 0)
@@ -53,14 +54,22 @@ func break_lines() -> void:
 			for row1 in range(row, 1, -1):
 				for col in range(width):
 					field[row1][col] = field[row1 - 1][col]
-	score += lines ** 2
+	match lines:
+		1: score +=   40 * (lines_broken/10 + 1)
+		2: score +=  100 * (lines_broken/10 + 1)
+		3: score +=  300 * (lines_broken/10 + 1)
+		4: score += 1200 * (lines_broken/10 + 1)
 	lines_broken += lines
 	line_broken.emit()
+	if lines_broken / 10 > (lines_broken - lines) / 10:
+		level_change.emit(lines_broken/10)
 	
 func go_space() -> void:
 	while !intersects():
 		figure.y += 1
+		score += 2
 	figure.y -= 1
+	score -= 2
 	freeze()
 	
 func get_shadow() -> Figure:

--- a/project.godot
+++ b/project.godot
@@ -21,6 +21,10 @@ Global="*res://AutoLoads/Global.gd"
 MusicManager="*res://AutoLoads/MusicManager.gd"
 GameDifficulty="*res://Scenes/LightsOut/GameDifficulty.gd"
 
+[debug]
+
+gdscript/warnings/integer_division=0
+
 [dotnet]
 
 project/assembly_name="GameHub"


### PR DESCRIPTION
Now pieces are falling at a rate based on the current level: `level = int(total_lines_broken)/10`
`wait_time = (0.8-(level*0.007))^(level)`

Score is also updated:
```py
match lines_broken:
	1: score +=   40 * (total_lines_broken/10 + 1)
	2: score +=  100 * (total_lines_broken/10 + 1)
	3: score +=  300 * (total_lines_broken/10 + 1)
	4: score += 1200 * (total_lines_broken/10 + 1)
```